### PR TITLE
tweak metrics

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -2,7 +2,6 @@ import {fileURLToPath} from 'node:url'
 import {readFileSync} from 'node:fs'
 import {inspect} from 'node:util'
 import {
-	parseEncodedFeed,
 	createParseAndProcessFeed,
 } from '../index.js'
 

--- a/index.js
+++ b/index.js
@@ -91,10 +91,6 @@ const createService = async (opt = {}) => {
 		}
 		logger.info(_logCtx, `creating new matcher for schedule database "${scheduleDatabaseName}"`)
 
-		// Note: Prometheus stores time series per combination of label values, so having labels with a high or even unbound cardinality is a problem. We still want to be able to tell the schedule databases' metrics apart in the monitoring system, so we add the first hex digit (with a cardinality of 16) of the GTFS Schedule feed's hash as a label.
-		// see also https://www.robustperception.io/cardinality-is-key/
-		const scheduleFeedDigestSlice = scheduleFeedDigest.slice(0, 1)
-
 		const {
 			parseAndProcessFeed: parseAndMatchRealtimeFeed,
 			stop: stopMatchingRealtimeFeed,
@@ -103,7 +99,6 @@ const createService = async (opt = {}) => {
 			// todo: pass realtimeFeedName through into metrics?
 			scheduleDatabaseName,
 			scheduleFeedDigest,
-			scheduleFeedDigestSlice,
 		})
 
 		const createFeedHandler = (realtimeFeedName) => {
@@ -117,7 +112,7 @@ const createService = async (opt = {}) => {
 				setFeed: setFeedMessage,
 				onRequest: serveFeedOnRequest,
 			} = serveFeed({
-				scheduleFeedDigest, scheduleFeedDigestSlice,
+				scheduleFeedDigest,
 			})
 
 			const processRealtimeFeed = ({feedEncoded}) => {

--- a/index.js
+++ b/index.js
@@ -268,7 +268,7 @@ const createService = async (opt = {}) => {
 		}
 
 		// /feeds/:realtimeFeedName?schedule-feed-digest
-		// todo: use express for routing?
+		// todo: use express or router for routing?
 		if (pathComponents[0] === 'feeds' && pathComponents.length === 2) {
 			const realtimeFeedName = pathComponents[1]
 			if (!realtimeFetchersByName.has(realtimeFeedName)) {

--- a/lib/apply-trip-replacement-periods.js
+++ b/lib/apply-trip-replacement-periods.js
@@ -107,7 +107,7 @@ const _tripReplPeriodsCanceledTripUpdatesTotal = new Gauge({
 
 const createApplyTripReplacementPeriods = (cfg) => {
 	const {
-		scheduleFeedDigest, scheduleFeedDigestSlice,
+		scheduleFeedDigest,
 		db,
 		logger,
 	} = cfg
@@ -224,7 +224,7 @@ const createApplyTripReplacementPeriods = (cfg) => {
 		})
 		const queryTime = (performance.now() - t0) / 1000
 		_queryTripReplPeriodsTimeSeconds.observe({
-			schedule_feed_digest: scheduleFeedDigestSlice,
+			schedule_feed_digest: scheduleFeedDigest,
 		}, queryTime)
 		logger.debug({
 			...logCtx,
@@ -239,7 +239,7 @@ const createApplyTripReplacementPeriods = (cfg) => {
 		const counts = Object.entries(countBy(canceled, ({route_id}) => route_id))
 		for (const [route_id, count] of counts) {
 			_tripReplPeriodsCanceledTripUpdatesTotal.set({
-				schedule_feed_digest: scheduleFeedDigestSlice,
+				schedule_feed_digest: scheduleFeedDigest,
 				route_id,
 			}, count)
 		}

--- a/lib/fetch-realtime-feed.js
+++ b/lib/fetch-realtime-feed.js
@@ -3,7 +3,7 @@
 import {createRequire} from 'module';
 const require = createRequire(import.meta.url);
 
-import {Summary} from 'prom-client'
+import {Gauge, Summary} from 'prom-client'
 import {ok} from 'node:assert'
 import {EventEmitter} from 'node:events';
 import ky from 'ky'
@@ -26,6 +26,12 @@ const FETCH_INTERVAL_MIN_MS = process.env.REALTIME_FEED_FETCH_MIN_INTERVAL
 
 const logger = createLogger('realtime-data', REALTIME_FETCHING_LOG_LEVEL)
 
+const lastFetchedTimestampSeconds = new Gauge({
+	name: 'realtime_feed_last_fetched_timestamp_seconds',
+	help: 'when the GTFS Realtime feed has last been fetched successfully',
+	registers: [metricsRegister],
+	labelNames: ['feed_name'],
+})
 const fetchDurationSeconds = new Summary({
 	name: 'realtime_feed_fetch_duration_seconds',
 	help: 'time needed to fetch the GTFS Realtime feed',
@@ -57,6 +63,7 @@ const startFetchingRealtimeFeed = (cfg) => {
 		const {signal} = abortController
 		events.on('abort', abortController.abort)
 
+		const tFetchStarted = Date.now()
 		const t0 = performance.now()
 		const res = await ky(realtimeFeedUrl, {
 			signal,
@@ -81,8 +88,10 @@ const startFetchingRealtimeFeed = (cfg) => {
 
 		logger.debug({
 			...logCtx,
+			tFetchStarted,
 			fetchDurationMs,
 		}, 'done fetching GTFS Realtime feed')
+		lastFetchedTimestampSeconds.set({feed_name: realtimeFeedName}, Math.round(tFetchStarted / 1000))
 		// todo: add more metrics, e.g. no. of requests, status codes, retries – use ky's opt.hooks?
 		fetchDurationSeconds.observe({feed_name: realtimeFeedName}, fetchDurationMs / 1000)
 

--- a/lib/match-alert.js
+++ b/lib/match-alert.js
@@ -7,7 +7,7 @@ import {queryScheduleStopTimes} from './query-schedule-stop-times.js'
 // 	const {
 // 		route_id,
 // 		trip_id,
-// 		scheduleFeedDigestSlice,
+// 		scheduleFeedDigest,
 // 		db,
 // 		matchingSuccesses,
 // 		matchingFailures,
@@ -43,20 +43,20 @@ import {queryScheduleStopTimes} from './query-schedule-stop-times.js'
 // 	})
 // 	const match = scheduleTrips.length === 1
 // 	dbQueryTimeSeconds.observe({
-// 		schedule_feed_digest: scheduleFeedDigestSlice,
+// 		schedule_feed_digest: scheduleFeedDigest,
 // 		route_id,
 // 		success: match,
 // 	}, (performance.now() - t0) / 1000)
 
 // 	if (match) {
 // 		matchingSuccesses.inc({
-// 			schedule_feed_digest: scheduleFeedDigestSlice,
+// 			schedule_feed_digest: scheduleFeedDigest,
 // 			route_id,
 // 		})
 // 		return scheduleTrips[0]
 // 	}
 // 	matchingFailures.inc({
-// 		schedule_feed_digest: scheduleFeedDigestSlice,
+// 		schedule_feed_digest: scheduleFeedDigest,
 // 		route_id,
 // 	})
 // 	return null
@@ -96,7 +96,7 @@ const matchingFailures = new Counter({
 
 const createMatchAlert = (cfg) => {
 	const {
-		scheduleFeedDigest, scheduleFeedDigestSlice,
+		scheduleFeedDigest,
 		realtimeFeedName,
 		db,
 		logger,
@@ -161,7 +161,7 @@ const createMatchAlert = (cfg) => {
 			// 	route_id,
 			// 	start_date,
 			// 	trip_id: realtimeTripId,
-			// 	scheduleFeedDigestSlice,
+			// 	scheduleFeedDigest,
 			// 	db,
 			// 	isMatch,
 			// 	matchingSuccesses,

--- a/lib/match-trip-update.js
+++ b/lib/match-trip-update.js
@@ -86,7 +86,7 @@ const stopTimeUpdateMatchingFailures = new Counter({
 
 const createMatchTripUpdate = (cfg) => {
 	const {
-		scheduleFeedDigest, scheduleFeedDigestSlice,
+		scheduleFeedDigest,
 		db,
 		logger,
 	} = cfg
@@ -146,7 +146,7 @@ const createMatchTripUpdate = (cfg) => {
 			trip_id: realtimeTripId,
 			stop_id: someStopTimeUpdate.stop_id,
 			stop_sequence: someStopTimeUpdate.stop_sequence ?? null,
-			scheduleFeedDigestSlice,
+			scheduleFeedDigest,
 			db,
 			isMatch,
 			matchingSuccesses,
@@ -213,7 +213,7 @@ const createMatchTripUpdate = (cfg) => {
 			})
 			if (scheduleStopTimesIdx === -1) {
 				stopTimeUpdateMatchingFailures.inc({
-					schedule_feed_digest: scheduleFeedDigestSlice,
+					schedule_feed_digest: scheduleFeedDigest,
 					route_id,
 				})
 				// todo: set StopTimeUpdate.schedule_relationship to SKIPPED?
@@ -222,7 +222,7 @@ const createMatchTripUpdate = (cfg) => {
 			}
 			const scheduleStopTime = scheduleStopTimes[scheduleStopTimesIdx]
 			stopTimeUpdateMatchingSuccesses.inc({
-				schedule_feed_digest: scheduleFeedDigestSlice,
+				schedule_feed_digest: scheduleFeedDigest,
 				route_id,
 			})
 			logger.trace({

--- a/lib/match-trip-update.js
+++ b/lib/match-trip-update.js
@@ -170,6 +170,9 @@ const createMatchTripUpdate = (cfg) => {
 		// We want to expose trip IDs matching the GTFS Schedule data.
 		tripUpdate.trip.trip_id = tripId
 
+		// > Frequency-based trips (GTFS frequencies.txt with exact_times = 0) should not have a SCHEDULED value and should use UNSCHEDULED instead.
+		// https://gtfs.org/realtime/reference/#enum-schedulerelationship
+		// (for now, we don't support frequencies.txt-based trips anyways)
 		tripUpdate.trip.schedule_relationship = ScheduleRelationship.SCHEDULED
 
 		let prevScheduleStopTimesIdx = -1

--- a/lib/match-vehicle-position.js
+++ b/lib/match-vehicle-position.js
@@ -40,7 +40,7 @@ const matchingFailures = new Counter({
 
 const createMatchVehiclePosition = (cfg) => {
 	const {
-		scheduleFeedDigest, scheduleFeedDigestSlice,
+		scheduleFeedDigest,
 		db,
 		logger,
 	} = cfg
@@ -89,7 +89,7 @@ const createMatchVehiclePosition = (cfg) => {
 			// todo: propose a spec change
 			stop_id,
 			stop_sequence: current_stop_sequence,
-			scheduleFeedDigestSlice,
+			scheduleFeedDigest,
 			db,
 			isMatch,
 			matchingSuccesses,

--- a/lib/match-vehicle-position.js
+++ b/lib/match-vehicle-position.js
@@ -121,6 +121,9 @@ const createMatchVehiclePosition = (cfg) => {
 		// We want to expose trip IDs matching the GTFS Schedule data.
 		vehiclePosition.trip.trip_id = scheduleStopTime.trip_id
 
+		// > Frequency-based trips (GTFS frequencies.txt with exact_times = 0) should not have a SCHEDULED value and should use UNSCHEDULED instead.
+		// https://gtfs.org/realtime/reference/#enum-schedulerelationship
+		// (for now, we don't support frequencies.txt-based trips anyways)
 		vehiclePosition.trip.schedule_relationship = ScheduleRelationship.SCHEDULED
 
 		// > When the trip_id corresponds to a non-frequency-based trip, this field should either be omitted or be equal to the value in the GTFS feed. When the trip_id correponds to a frequency-based trip defined in GTFS frequencies.txt, start_time is required and must be specified for trip updates and vehicle positions.

--- a/lib/match.js
+++ b/lib/match.js
@@ -56,31 +56,30 @@ const _matchingTimeSeconds = new Gauge({
 const createParseAndProcessFeed = async (cfg) => {
 	const {
 		scheduleDatabaseName,
-		scheduleFeedDigest, scheduleFeedDigestSlice,
+		scheduleFeedDigest,
 		// todo: expect realtimeFeedName, pass through to matching fns
 	} = cfg
 	ok(scheduleDatabaseName, 'scheduleDatabaseName must not be empty')
 	ok(scheduleFeedDigest, 'scheduleFeedDigest must not be empty')
-	ok(scheduleFeedDigestSlice, 'scheduleFeedDigestSlice must not be empty')
 
 	const db = await connectToPostgres({
 		database: scheduleDatabaseName,
 	})
 
 	const {matchTripUpdate} = createMatchTripUpdate({
-		scheduleFeedDigest, scheduleFeedDigestSlice,
+		scheduleFeedDigest,
 		db,
 		logger: createLogger('match-trip-update', MATCHING_LOG_LEVEL),
 		metricsRegister,
 	})
 	const {matchVehiclePosition} = createMatchVehiclePosition({
-		scheduleFeedDigest, scheduleFeedDigestSlice,
+		scheduleFeedDigest,
 		db,
 		logger: createLogger('match-vehicle-position', MATCHING_LOG_LEVEL),
 		metricsRegister,
 	})
 	const {matchAlert} = createMatchAlert({
-		scheduleFeedDigest, scheduleFeedDigestSlice,
+		scheduleFeedDigest,
 		db,
 		logger: createLogger('match-alert', MATCHING_LOG_LEVEL),
 		metricsRegister,
@@ -158,7 +157,7 @@ const createParseAndProcessFeed = async (cfg) => {
 		await Promise.all(feedMessage.entity.map(queueFeedEntityMatching))
 		const matchingTime = (performance.now() - t0) / 1000
 		_matchingTimeSeconds.set({
-			'schedule_feed_digest': scheduleFeedDigestSlice,
+			'schedule_feed_digest': scheduleFeedDigest,
 		}, matchingTime)
 		_logger.debug({
 			...logCtx,
@@ -172,14 +171,14 @@ const createParseAndProcessFeed = async (cfg) => {
 		storeAndRestoreStopTimeUpdatesFromDb,
 		startCleaningOldStoredStopTimeUpdates,
 	} = createStoreAndRestoreStopTimeUpdatesFromDb({
-		scheduleFeedDigest, scheduleFeedDigestSlice,
+		scheduleFeedDigest,
 		db,
 		logger: createLogger('store-stoptimeupdates', MATCHING_LOG_LEVEL),
 		metricsRegister,
 	})
 
 	const applyTripReplacementPeriods = createApplyTripReplacementPeriods({
-		scheduleFeedDigest, scheduleFeedDigestSlice,
+		scheduleFeedDigest,
 		db,
 		logger: createLogger('trip-replacement-periods', MATCHING_LOG_LEVEL),
 		metricsRegister,

--- a/lib/query-schedule-stop-times.js
+++ b/lib/query-schedule-stop-times.js
@@ -112,7 +112,7 @@ const queryScheduleStopTimes = async (cfg) => {
 		trip_id,
 		stop_id = null,
 		stop_sequence = null,
-		scheduleFeedDigestSlice,
+		scheduleFeedDigest,
 		realtimeFeedName,
 		db,
 		isMatch,
@@ -129,7 +129,7 @@ const queryScheduleStopTimes = async (cfg) => {
 	strictEqual(typeof isMatch, 'function', 'isMatch must be a function')
 
 	const logCtx = {
-		scheduleFeedDigestSlice,
+		scheduleFeedDigest,
 		realtimeFeedName,
 	}
 
@@ -156,7 +156,7 @@ const queryScheduleStopTimes = async (cfg) => {
 	}
 
 	const metricsCtx = {
-		schedule_feed_digest: scheduleFeedDigestSlice,
+		schedule_feed_digest: scheduleFeedDigest,
 		route_id,
 	}
 

--- a/lib/query-schedule-stop-times.js
+++ b/lib/query-schedule-stop-times.js
@@ -133,7 +133,7 @@ const queryScheduleStopTimes = async (cfg) => {
 		realtimeFeedName,
 	}
 
-	// Without stop_id, it is not possible to unambiguously identify the targeted trip "instance", as there might be two trips with the same trip_id *suffix* running by the same stop one the same date.
+	// Without stop_id, it is not possible to unambiguously identify the targeted trip "instance", as there might be two trips with the same trip_id *suffix* visiting the same stop on the same date.
 	if (stop_id === null) {
 		logger.warn({
 			...logCtx,

--- a/lib/refresh-schedule-feeds.js
+++ b/lib/refresh-schedule-feeds.js
@@ -205,7 +205,7 @@ const startRefreshingScheduleFeed = (cfg) => {
 				currentDatabases,
 			})
 
-			// wait so that we pull every `FETCH_INTERVAL_MS`, but at least `FETCH_INTERVAL_MIN_MS`
+			// wait so that we pull at best every `FETCH_INTERVAL_MS`, but at most every `FETCH_INTERVAL_MIN_MS`
 			const _waitMs = Math.max(FETCH_INTERVAL_MS - timePassedMs, FETCH_INTERVAL_MIN_MS)
 			await new Promise((resolve) => {
 				waitTimer = setTimeout(resolve, _waitMs)

--- a/lib/refresh-schedule-feeds.js
+++ b/lib/refresh-schedule-feeds.js
@@ -76,6 +76,7 @@ const fetchAndImportScheduleFeed = async (cfg) => {
 		feedName,
 		gtfsDownloadUrl,
 		fetchDurationSeconds,
+		importAttemptedTimestampSeconds,
 		importedTimestampSeconds,
 		importDurationSeconds,
 	} = cfg
@@ -84,6 +85,7 @@ const fetchAndImportScheduleFeed = async (cfg) => {
 	const verboseLogging = _importerLogger.isLevelEnabled('trace')
 
 	const tImportStarted = Date.now()
+	importAttemptedTimestampSeconds.set({feed_name: feedName}, Math.round(tImportStarted / 1000))
 
 	const res = await importGtfsAtomically({
 		logger: _importerLogger,
@@ -117,6 +119,12 @@ const fetchAndImportScheduleFeed = async (cfg) => {
 const fetchDurationSeconds = new Summary({
 	name: 'schedule_feed_fetch_duration_seconds',
 	help: 'time needed to fetch the GTFS Schedule feed',
+	registers: [metricsRegister],
+	labelNames: ['feed_name'],
+})
+const importAttemptedTimestampSeconds = new Gauge({
+	name: 'schedule_feed_import_attempted_timestamp_seconds',
+	help: 'when a new Schedule feed (version) has last been *attempted* to be imported, regardless of the result',
 	registers: [metricsRegister],
 	labelNames: ['feed_name'],
 })
@@ -176,6 +184,7 @@ const startRefreshingScheduleFeed = (cfg) => {
 				feedName: scheduleFeedName,
 				gtfsDownloadUrl: scheduleFeedUrl,
 				fetchDurationSeconds,
+				importAttemptedTimestampSeconds,
 				importedTimestampSeconds,
 				importDurationSeconds,
 			})

--- a/lib/refresh-schedule-feeds.js
+++ b/lib/refresh-schedule-feeds.js
@@ -76,12 +76,14 @@ const fetchAndImportScheduleFeed = async (cfg) => {
 		feedName,
 		gtfsDownloadUrl,
 		fetchDurationSeconds,
-		dataImported,
+		importedTimestampSeconds,
 		importDurationSeconds,
 	} = cfg
 	const databaseNamePrefix = `${DB_NAME_PREFIX}${feedName}_`
 
 	const verboseLogging = _importerLogger.isLevelEnabled('trace')
+
+	const tImportStarted = Date.now()
 
 	const res = await importGtfsAtomically({
 		logger: _importerLogger,
@@ -104,7 +106,9 @@ const fetchAndImportScheduleFeed = async (cfg) => {
 	} = res
 
 	fetchDurationSeconds.observe({feed_name: feedName}, downloadDurationMs / 1000)
-	dataImported.set({feed_name: feedName}, importSkipped ? 0 : 1)
+	if (!importSkipped) {
+		importedTimestampSeconds.set({feed_name: feedName}, Math.round(tImportStarted / 1000))
+	}
 	importDurationSeconds.observe({feed_name: feedName}, importDurationMs / 1000)
 
 	return res
@@ -116,10 +120,9 @@ const fetchDurationSeconds = new Summary({
 	registers: [metricsRegister],
 	labelNames: ['feed_name'],
 })
-// todo [breaking]: change to timestamp, rename to `schedule_feed_imported_timestamp_seconds`
-const dataImported = new Gauge({
-	name: 'schedule_feed_imported_boolean',
-	help: 'during the last fetch/import cycle, if the feed has changed and thus been imported',
+const importedTimestampSeconds = new Gauge({
+	name: 'schedule_feed_imported_timestamp_seconds',
+	help: 'when a new Schedule feed (version) has last been imported successfully',
 	registers: [metricsRegister],
 	labelNames: ['feed_name'],
 })
@@ -173,7 +176,7 @@ const startRefreshingScheduleFeed = (cfg) => {
 				feedName: scheduleFeedName,
 				gtfsDownloadUrl: scheduleFeedUrl,
 				fetchDurationSeconds,
-				dataImported,
+				importedTimestampSeconds,
 				importDurationSeconds,
 			})
 			const timePassedMs = performance.now() - t0

--- a/lib/restore-stoptimeupdates.js
+++ b/lib/restore-stoptimeupdates.js
@@ -81,7 +81,7 @@ const noCleaned = new Gauge({
 
 const createStoreAndRestoreStopTimeUpdatesFromDb = (cfg) => {
 	const {
-		scheduleFeedDigest, scheduleFeedDigestSlice,
+		scheduleFeedDigest,
 		db,
 		logger,
 		// todo: expect realtimeFeedName, add to logCtx
@@ -216,7 +216,7 @@ const createStoreAndRestoreStopTimeUpdatesFromDb = (cfg) => {
 		])
 		const queryTime = (performance.now() - t0) / 1000
 		storeQueryTimeSeconds.observe({
-			schedule_feed_digest: scheduleFeedDigestSlice,
+			schedule_feed_digest: scheduleFeedDigest,
 		}, queryTime)
 		logger.debug({
 			...logCtx,
@@ -284,7 +284,7 @@ const createStoreAndRestoreStopTimeUpdatesFromDb = (cfg) => {
 		} = await db.query(query, values)
 		const queryTime = (performance.now() - t0) / 1000
 		restoreQueryTimeSeconds.observe({
-			schedule_feed_digest: scheduleFeedDigestSlice,
+			schedule_feed_digest: scheduleFeedDigest,
 		}, queryTime)
 		logger.debug({
 			...logCtx,
@@ -392,10 +392,10 @@ const createStoreAndRestoreStopTimeUpdatesFromDb = (cfg) => {
 		})
 		const queryTime = (performance.now() - t0) / 1000
 		cleanQueryTimeSeconds.observe({
-			schedule_feed_digest: scheduleFeedDigestSlice,
+			schedule_feed_digest: scheduleFeedDigest,
 		}, queryTime)
 		noCleaned.set({
-			schedule_feed_digest: scheduleFeedDigestSlice,
+			schedule_feed_digest: scheduleFeedDigest,
 		}, nrOfStopTimeUpdates)
 		logger.debug({
 			...logCtx,

--- a/lib/serve-gtfs-rt.js
+++ b/lib/serve-gtfs-rt.js
@@ -34,7 +34,7 @@ const encodedFeedSizeBytes = new Gauge({
 
 const serveFeed = (cfg) => {
 	const {
-		scheduleFeedDigestSlice,
+		scheduleFeedDigest,
 	} = cfg
 
 	// modeled after https://github.com/derhuerst/hafas-gtfs-rt-feed/blob/8.2.3/lib/serve.js#L144-L152
@@ -46,7 +46,7 @@ const serveFeed = (cfg) => {
 		feed = encodeFeedMessage(feedMessage)
 		timeModified = new Date()
 		encodedFeedSizeBytes.set({
-			schedule_feed_digest: scheduleFeedDigestSlice,
+			schedule_feed_digest: scheduleFeedDigest,
 		}, feed.length)
 		etag = computeEtag(feed)
 	}

--- a/test/01-match.js
+++ b/test/01-match.js
@@ -15,7 +15,6 @@ const {ScheduleRelationship} = gtfsRtBindings.transit_realtime.TripDescriptor
 const SCHEDULE_DB_NAME = process.env.PGDATABASE
 ok(SCHEDULE_DB_NAME, 'SCHEDULE_DB_NAME')
 const SCHEDULE_FEED_DIGEST = 'ce8d9c' // first 3 bytes of SHA-256 hash
-const SCHEDULE_FEED_DIGEST_SLICE = SCHEDULE_FEED_DIGEST.slice(0, 1)
 
 const tripUpdate072350_1_N03RScheduleTripId = 'AFA23GEN-1092-Weekday-00_072350_1..N03R'
 const tripUpdate072350_1_N03R = {
@@ -262,7 +261,6 @@ const {
 } = await createParseAndProcessFeed({
 	scheduleDatabaseName: SCHEDULE_DB_NAME,
 	scheduleFeedDigest: SCHEDULE_FEED_DIGEST,
-	scheduleFeedDigestSlice: SCHEDULE_FEED_DIGEST_SLICE,
 })
 
 after(async () => {

--- a/test/01-match.js
+++ b/test/01-match.js
@@ -293,7 +293,7 @@ test('matching a S03R VehiclePosition works', async (t) => {
 	deepStrictEqual(vehiclePosition, vehiclePosition075150_1_S03RMatched)
 })
 
-test('matchTripUpdate() correctly filter by suffix', async (t) => {
+test('matchTripUpdate() correctly filters by suffix', async (t) => {
 	const now = 1710953000_000
 	const prefixed = {
 		...tripUpdate072350_1_N03R,

--- a/test/02-service.js
+++ b/test/02-service.js
@@ -146,7 +146,7 @@ const purgeTestDbs = async () => {
 
 const debugLogMatchingMetrics = (metrics) => {
 	logger.debug({
-		schedule_feed_imported_boolean: metrics.schedule_feed_imported_boolean.data,
+		schedule_feed_imported_timestamp_seconds: metrics.schedule_feed_imported_timestamp_seconds.data,
 		tripupdates_matching_successes_total: metrics.tripupdates_matching_successes_total.data,
 		tripupdates_matching_failures_total: metrics.tripupdates_matching_failures_total.data,
 		vehiclepositions_matching_successes_total: metrics.vehiclepositions_matching_successes_total.data,
@@ -347,6 +347,7 @@ test('importing Schedule feed, matching & serving Realtime feed works', async (t
 
 	const pTest = (async () => {
 		// check matching with FOO_FEED
+		const tBeforeImportFoo = Date.now()
 		// todo: get notified about schedule re-import instead of waiting
 		await new Promise(r => setTimeout(r, 3_000)) // wait for Schedule feed to be imported
 		{
@@ -381,16 +382,19 @@ test('importing Schedule feed, matching & serving Realtime feed works', async (t
 			})
 			debugLogMatchingMetrics(metrics)
 
-			const scheduleFeedImported = metrics.schedule_feed_imported_boolean.data
+			const scheduleFeedImported = metrics.schedule_feed_imported_timestamp_seconds.data
 			.find(({labels: l}) => l.feed_name === scheduleFeedName)
-			// imported for the first time
-			strictEqual(scheduleFeedImported?.value, 1, 'schedule_feed_imported_boolean should be 1')
+			ok(
+				scheduleFeedImported?.value >= Math.round(tBeforeImportFoo / 1000),
+				'schedule_feed_imported_timestamp_seconds should be larger than tBeforeImportFoo',
+			)
 
 			checkTripUpdatesMatchingSuccessesAndFailures(metrics, 'trip_by_suffix_stop_id')
 			checkVehiclePositionsMatchingSuccessesAndFailures(metrics, 'stop_times_by_suffix_stop_id_stop_seq')
 		}
 
 		// check matching with BAR_FEED
+		const tBeforeImportBar = Date.now()
 		setScheduleFeed(BAR_FEED)
 		scheduleFeedDigest = BAR_FEED_DIGEST
 		// todo: trigger & get notified about schedule re-import instead of waiting
@@ -424,16 +428,20 @@ test('importing Schedule feed, matching & serving Realtime feed works', async (t
 			})
 			debugLogMatchingMetrics(metrics)
 
-			const scheduleFeedImported = metrics.schedule_feed_imported_boolean.data
+			const scheduleFeedImported = metrics.schedule_feed_imported_timestamp_seconds.data
 			.find(({labels: l}) => l.feed_name === scheduleFeedName)
 			// imported again because the Schedule feed's digest has changed
-			strictEqual(scheduleFeedImported?.value, 1, 'schedule_feed_imported_boolean should be 1')
+			ok(
+				scheduleFeedImported?.value >= Math.round(tBeforeImportBar / 1000),
+				'schedule_feed_imported_timestamp_seconds should be larger than tBeforeImportBar',
+			)
 
 			checkTripUpdatesMatchingSuccessesAndFailures(metrics, 'trip_by_suffix_stop_id')
 			checkVehiclePositionsMatchingSuccessesAndFailures(metrics, 'stop_times_by_suffix_stop_id_stop_seq')
 		}
 
 		// modify realtime feed, check matching with BAR_FEED again
+		const tModifyRealtime = Date.now()
 		setRealtimeFeed(encodeFeedMessage(feedMessage1))
 		// todo: trigger & get notified about realtime fetching instead of waiting
 		await new Promise(r => setTimeout(r, 3_000))
@@ -459,10 +467,17 @@ test('importing Schedule feed, matching & serving Realtime feed works', async (t
 			})
 			debugLogMatchingMetrics(metrics)
 
-			const scheduleFeedImported = metrics.schedule_feed_imported_boolean.data
+			const scheduleFeedImported = metrics.schedule_feed_imported_timestamp_seconds.data
 			.find(({labels: l}) => l.feed_name === scheduleFeedName)
 			// not imported again because the Schedule feed's digest hasn't changed
-			strictEqual(scheduleFeedImported?.value, 0, 'schedule_feed_imported_boolean should be 0')
+			ok(
+				scheduleFeedImported?.value >= Math.round(tBeforeImportBar / 1000),
+				'schedule_feed_imported_timestamp_seconds should be larger than tBeforeImportBar',
+			)
+			ok(
+				scheduleFeedImported?.value < Math.round(tModifyRealtime / 1000),
+				'schedule_feed_imported_timestamp_seconds should be smaller than tModifyRealtime',
+			)
 
 			checkTripUpdatesMatchingSuccessesAndFailures(metrics, 'trip_by_suffix_stop_id')
 			checkVehiclePositionsMatchingSuccessesAndFailures(metrics, 'stop_times_by_suffix_stop_id_stop_seq')

--- a/test/03-match.js
+++ b/test/03-match.js
@@ -13,7 +13,6 @@ const SCHEDULE_DB_NAME = process.env.PGDATABASE
 ok(SCHEDULE_DB_NAME, 'SCHEDULE_DB_NAME')
 // `sha256sum node_modules/sample-gtfs-feed/gtfs.zip`
 const SCHEDULE_FEED_DIGEST = '3669d7' // first 3 bytes of SHA-256 hash
-const SCHEDULE_FEED_DIGEST_SLICE = SCHEDULE_FEED_DIGEST.slice(0, 1)
 
 // from sample-gtfs-feed@0.13's `stop_times.js`:
 // > ```
@@ -142,7 +141,6 @@ const {
 } = await createParseAndProcessFeed({
 	scheduleDatabaseName: SCHEDULE_DB_NAME,
 	scheduleFeedDigest: SCHEDULE_FEED_DIGEST,
-	scheduleFeedDigestSlice: SCHEDULE_FEED_DIGEST_SLICE,
 })
 
 after(async () => {


### PR DESCRIPTION
This PR improves the observability of Schedule feed imports and Realtime feed fetches by
- changing to/adding "last imported" timestamp metrics, and
- using the full length for the `schedule_feed_digest` labels.